### PR TITLE
Edit route count, color, belong class

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -113,8 +113,8 @@ function addRoute(i, summaryPolyline) {
             "line-cap": "round"
         },
         "paint": {
-            "line-color": "#" + ((i + 1) * 333),
-            "line-width": 5
+            "line-color": '#FC4C02',
+            "line-width": 3
         }
     });
 };

--- a/app/controllers/api/v1/issues_controller.rb
+++ b/app/controllers/api/v1/issues_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::IssuesController < ApplicationController
   def index
-    current_id = current_user.id if current_user
+    current_id = cookies[:id] ? cookies[:id].to_i : -1
     render json: Issue.all, current_id: current_id
   end
 end

--- a/app/services/strava_service.rb
+++ b/app/services/strava_service.rb
@@ -16,7 +16,6 @@ class StravaService
   def recent_routes
     response = conn.get do |req|
       req.params['access_token'] = token
-      req.params['per_page']     = 3
     end
     raw_routes = JSON.parse(response.body)
     summary_polylines(raw_routes) rescue []

--- a/app/services/strava_service.rb
+++ b/app/services/strava_service.rb
@@ -16,6 +16,7 @@ class StravaService
   def recent_routes
     response = conn.get do |req|
       req.params['access_token'] = token
+      req.params['per_page']     = 7
     end
     raw_routes = JSON.parse(response.body)
     summary_polylines(raw_routes) rescue []

--- a/spec/fixtures/vcr_cassettes/recent/routes_api_invalid_user_id_returns_404.yml
+++ b/spec/fixtures/vcr_cassettes/recent/routes_api_invalid_user_id_returns_404.yml
@@ -23,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 23:25:23 GMT
+      - Sat, 25 Feb 2017 00:28:51 GMT
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTcxY2MwNDMyZWY3NDg4ZmZkZDIyOGZiYjM2OTIwZDc0BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--99e4ca1028da81bf30bc69e647e63d77f34e436f;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTUyODdiMGE3NmNjNjMyZmY2YjVjYzkwOWY3Y2NlMGI5BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--52cb343ceffddb623974f3659c5a659d26846831;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 401 Unauthorized
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cc38f22b3232877382d5e9695df7a36
+      - 24db3c14cd2e1318203754adbc523478
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"Authorization Error","errors":[{"resource":"Athlete","field":"access_token","code":"invalid"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 23:25:23 GMT
+  recorded_at: Sat, 25 Feb 2017 00:28:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/recent/routes_api_invalid_user_id_returns_404.yml
+++ b/spec/fixtures/vcr_cassettes/recent/routes_api_invalid_user_id_returns_404.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?access_token=&per_page=3
+    uri: https://www.strava.com/api/v3/athlete/activities?access_token=&per_page=7
     body:
       encoding: US-ASCII
       string: ''
@@ -23,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 17:56:04 GMT
+      - Fri, 24 Feb 2017 23:25:23 GMT
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTcyOWQxNDc4MmY4MTYyMjgyNzhiNjk5ZWJmNmI1YWM4BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--c7df271d0f336e0c26ce89281f92bc33b9402029;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTcxY2MwNDMyZWY3NDg4ZmZkZDIyOGZiYjM2OTIwZDc0BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--99e4ca1028da81bf30bc69e647e63d77f34e436f;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 401 Unauthorized
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfd7df86d3040707fefec996839e18d5
+      - 6cc38f22b3232877382d5e9695df7a36
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"Authorization Error","errors":[{"resource":"Athlete","field":"access_token","code":"invalid"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 17:56:04 GMT
+  recorded_at: Fri, 24 Feb 2017 23:25:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_invalid_token_returns_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_invalid_token_returns_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?access_token=invalid_token&per_page=3
+    uri: https://www.strava.com/api/v3/athlete/activities?access_token=invalid_token&per_page=7
     body:
       encoding: US-ASCII
       string: ''
@@ -23,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 17:56:04 GMT
+      - Fri, 24 Feb 2017 23:25:23 GMT
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTgwNjViZTljYjlmN2VhMzhiMDFkOGJiOGI4NTE4YmZhBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--aa3e7bbba1fabc17b5598c7e69c19ef345cfd509;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTEwOGQyNjQ0ZmZjMzI0YjE1NzIwY2YxMjBjOWQ1ZTE0BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--c0436afa2bbb2413dfbd090a5fb6c7d97febdebb;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 401 Unauthorized
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 931c84304fd4944e0f12d8cd1309edb1
+      - 9ec1214f1f17cbb1a9d74daa9009d4be
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"Authorization Error","errors":[{"resource":"Athlete","field":"access_token","code":"invalid"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 17:56:04 GMT
+  recorded_at: Fri, 24 Feb 2017 23:25:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_invalid_token_returns_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_invalid_token_returns_empty_array.yml
@@ -23,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 23:25:23 GMT
+      - Sat, 25 Feb 2017 00:28:51 GMT
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTEwOGQyNjQ0ZmZjMzI0YjE1NzIwY2YxMjBjOWQ1ZTE0BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--c0436afa2bbb2413dfbd090a5fb6c7d97febdebb;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTUxMDg5YWM2YzkwNTliMjBmYjQzNDJmOTVlMTQzMjBiBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--8e5216ba464ae71a9b8e129ed0fa3228fd772897;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 401 Unauthorized
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ec1214f1f17cbb1a9d74daa9009d4be
+      - a5107bbb2fc9b2297c25d37aba7b67d5
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"Authorization Error","errors":[{"resource":"Athlete","field":"access_token","code":"invalid"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 23:25:23 GMT
+  recorded_at: Sat, 25 Feb 2017 00:28:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_valid_token_returns_users_3_most_recent_routes.yml
+++ b/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_valid_token_returns_users_3_most_recent_routes.yml
@@ -23,11 +23,11 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 23:25:23 GMT
+      - Sat, 25 Feb 2017 00:28:51 GMT
       Etag:
       - W/"72ce9c580a8032e0e2277d59c56fc7c2"
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWU1ODM4MjEyNjZmNjJiYjI4MjllNGRmZjRhOGJhZGY0BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--8fa43cdb15c4f6549ea96a16e30e3d1311e1fc28;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWQ3OTMyZmI1MjNlNTJkMzZiYjQ3OWIwNjBlNzcwZjdhBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--8003bc3368678ce417241b657158df4ee3571c93;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 200 OK
@@ -38,9 +38,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600,30000'
       X-Ratelimit-Usage:
-      - '12,117'
+      - '7,17'
       X-Request-Id:
-      - 572ad89e52f9b62df85c3b5ead0bc95b
+      - 64d5345f0e3a2147c6a3b718364d143e
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -65,5 +65,5 @@ http_interactions:
         Ride","distance":7196.7,"moving_time":1164,"elapsed_time":1318,"total_elevation_gain":10.0,"type":"Ride","start_date":"2017-02-16T14:43:09Z","start_date_local":"2017-02-16T07:43:09Z","timezone":"(GMT-07:00)
         America/Denver","utc_offset":-25200.0,"start_latlng":[39.76,-105.06],"end_latlng":[39.75,-105.0],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.76,"start_longitude":-105.06,"achievement_count":1,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a868441229","summary_polyline":"ggsqFdmd`S@oShE{ObD_C?oyCo@mKoQqh@`B_CmAwAdEuAnSsYiP}VjJgNqBqFwBk@vE~AgFuC`@cAErBV_B~AdC","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":6.183,"max_speed":16.7,"average_watts":84.3,"kilojoules":98.1,"device_watts":false,"has_heartrate":false,"elev_high":1642.4,"elev_low":1576.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10}]'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 23:25:23 GMT
+  recorded_at: Sat, 25 Feb 2017 00:28:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_valid_token_returns_users_3_most_recent_routes.yml
+++ b/spec/fixtures/vcr_cassettes/recent/routes_api_logged_in_user_with_valid_token_returns_users_3_most_recent_routes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?access_token=<ACCESS_TOKEN>&per_page=3
+    uri: https://www.strava.com/api/v3/athlete/activities?access_token=<ACCESS_TOKEN>&per_page=7
     body:
       encoding: US-ASCII
       string: ''
@@ -23,28 +23,28 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 17:56:03 GMT
+      - Fri, 24 Feb 2017 23:25:23 GMT
       Etag:
-      - W/"f0827a546cc74cc1552b0eb48ac97b56"
+      - W/"72ce9c580a8032e0e2277d59c56fc7c2"
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJThiMWVkMTg0ZmFlZDRjYmI4MzQwOGI2YzZlZjA5MTc1BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--094b826ab982ff24470272cd5ba16810202d0485;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWU1ODM4MjEyNjZmNjJiYjI4MjllNGRmZjRhOGJhZGY0BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--8fa43cdb15c4f6549ea96a16e30e3d1311e1fc28;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 200 OK
       Strava-Athlete-Upload-Version:
-      - 51ab7e215dabab38aace5691faca731e
+      - d4734f82304b91efb9c7be9c3eacd1af
       X-Frame-Options:
       - DENY
       X-Ratelimit-Limit:
       - '600,30000'
       X-Ratelimit-Usage:
-      - '5,26'
+      - '12,117'
       X-Request-Id:
-      - 6051d594f57adea0ca907d93fc3212f5
+      - 572ad89e52f9b62df85c3b5ead0bc95b
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
-      - '1161'
+      - '2107'
       Connection:
       - keep-alive
     body:
@@ -55,7 +55,15 @@ http_interactions:
         Ride","distance":6748.0,"moving_time":1417,"elapsed_time":1959,"total_elevation_gain":65.3,"type":"Ride","start_date":"2017-02-21T01:09:58Z","start_date_local":"2017-02-20T18:09:58Z","timezone":"(GMT-07:00)
         America/Denver","utc_offset":-25200.0,"start_latlng":[39.75,-105.0],"end_latlng":[39.76,-105.06],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.75,"start_longitude":-105.0,"achievement_count":2,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a874072613","summary_polyline":"e_sqFd}y_Sl@WqBtBvBFFmBoMjRbVt^aThYsDhA|@xBoAfBjCzDJ`EpLx\\f@jI^l~CeDtBeFhNCtQ","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":4.762,"max_speed":11.7,"average_watts":84.8,"kilojoules":120.2,"device_watts":false,"has_heartrate":false,"elev_high":1642.3,"elev_low":1576.0,"pr_count":2,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":872969283,"resource_state":2,"external_id":"79EC0036-DB8C-42E9-AC26-937116D9B123","upload_id":965871320,"athlete":{"id":19613252,"resource_state":1},"name":"Afternoon
         Ride","distance":8115.6,"moving_time":1615,"elapsed_time":1793,"total_elevation_gain":58.8,"type":"Ride","start_date":"2017-02-20T00:32:51Z","start_date_local":"2017-02-19T17:32:51Z","timezone":"(GMT-07:00)
-        America/Denver","utc_offset":-25200.0,"start_latlng":[39.73,-105.0],"end_latlng":[39.76,-105.06],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.73,"start_longitude":-105.0,"achievement_count":6,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a872969283","summary_polyline":"kzmqFrj{_SkgA@Pr}A_L`AqXsHg@pDfCvOqH`MHflAs@bK_FEmEpFmFnPcBnMgFSkSrKgAjJpDzKAbF","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":5.025,"max_speed":8.8,"average_watts":89.0,"kilojoules":143.7,"device_watts":false,"has_heartrate":false,"elev_high":1641.2,"elev_low":1582.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10}]'
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.73,-105.0],"end_latlng":[39.76,-105.06],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.73,"start_longitude":-105.0,"achievement_count":6,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a872969283","summary_polyline":"kzmqFrj{_SkgA@Pr}A_L`AqXsHg@pDfCvOqH`MHflAs@bK_FEmEpFmFnPcBnMgFSkSrKgAjJpDzKAbF","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":5.025,"max_speed":8.8,"average_watts":89.0,"kilojoules":143.7,"device_watts":false,"has_heartrate":false,"elev_high":1641.2,"elev_low":1582.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":872526686,"resource_state":2,"external_id":"032881FD-3436-4602-A230-7C4D040406FB","upload_id":965417202,"athlete":{"id":19613252,"resource_state":1},"name":"Morning
+        Ride","distance":10291.0,"moving_time":1732,"elapsed_time":1795,"total_elevation_gain":43.8,"type":"Ride","start_date":"2017-02-19T17:10:33Z","start_date_local":"2017-02-19T10:10:33Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.76,-105.06],"end_latlng":[39.73,-104.97],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.76,"start_longitude":-105.06,"achievement_count":0,"kudos_count":0,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a872526686","summary_polyline":"egsqFtmd`SAmTvE{O~C_BGw|Co@gIgMq]G{CaCaDxAyBeAoBlEiBz`@{g@~YgCzNqFbpAo~@dHqP{C_BDwnAuOBnAZ","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":5.942,"max_speed":10.5,"average_watts":96.4,"kilojoules":167.0,"device_watts":false,"has_heartrate":false,"elev_high":1641.3,"elev_low":1576.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":870060166,"resource_state":2,"external_id":"8B2A3A6B-A409-480E-A9E7-664FCF6A7ECD","upload_id":962755487,"athlete":{"id":19613252,"resource_state":1},"name":"Afternoon
+        Ride","distance":5368.9,"moving_time":1083,"elapsed_time":1238,"total_elevation_gain":48.1,"type":"Ride","start_date":"2017-02-18T00:17:50Z","start_date_local":"2017-02-17T17:17:50Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.75,-105.0],"end_latlng":[39.75,-105.05],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.75,"start_longitude":-105.0,"achievement_count":6,"kudos_count":0,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a870060166","summary_polyline":"uzrqFhxz_SyCzEzIlOsSrXwD`Bv@|BgAlBvPhh@x@lNVvyCcD~BqFdNFxQ","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":4.957,"max_speed":9.0,"average_watts":110.0,"kilojoules":119.1,"device_watts":false,"has_heartrate":false,"elev_high":1625.0,"elev_low":1576.5,"pr_count":4,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":870047117,"resource_state":2,"external_id":"43AC557B-9962-45BE-B4AB-0ECB03D162AB","upload_id":962739093,"athlete":{"id":19613252,"resource_state":1},"name":"Afternoon
+        Ride","distance":9151.6,"moving_time":1992,"elapsed_time":90986,"total_elevation_gain":57.8,"type":"Ride","start_date":"2017-02-16T23:00:57Z","start_date_local":"2017-02-16T16:00:57Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.77,-105.22],"end_latlng":[39.73,-105.0],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.77,"start_longitude":-105.22,"achievement_count":2,"kudos_count":0,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a870047117","summary_polyline":"oyvqFpbfaSgH_@kBnDgMD}QyDqAqClqAsHzz@ip^hSN?ugAtE{P|@uApTo@tEaUxEmJxEgChE~@FszAfG{HAmFoBmF^{HnX|HvKyAZc|AbfAs@","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":4.594,"max_speed":11.1,"average_watts":82.9,"kilojoules":165.1,"device_watts":false,"has_heartrate":false,"elev_high":2004.9,"elev_low":1582.1,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":868441229,"resource_state":2,"external_id":"A8E68656-F471-465B-9E04-BC82FACBB260","upload_id":961037581,"athlete":{"id":19613252,"resource_state":1},"name":"Morning
+        Ride","distance":7196.7,"moving_time":1164,"elapsed_time":1318,"total_elevation_gain":10.0,"type":"Ride","start_date":"2017-02-16T14:43:09Z","start_date_local":"2017-02-16T07:43:09Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.76,-105.06],"end_latlng":[39.75,-105.0],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.76,"start_longitude":-105.06,"achievement_count":1,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a868441229","summary_polyline":"ggsqFdmd`S@oShE{ObD_C?oyCo@mKoQqh@`B_CmAwAdEuAnSsYiP}VjJgNqBqFwBk@vE~AgFuC`@cAErBV_B~AdC","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":6.183,"max_speed":16.7,"average_watts":84.3,"kilojoules":98.1,"device_watts":false,"has_heartrate":false,"elev_high":1642.4,"elev_low":1576.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10}]'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 17:56:03 GMT
+  recorded_at: Fri, 24 Feb 2017 23:25:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_invalid_token_returns_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_invalid_token_returns_empty_array.yml
@@ -23,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 23:25:24 GMT
+      - Sat, 25 Feb 2017 00:28:52 GMT
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTUyMzRkYjc5ODNmNzZkNWUyOWQzMWMxZmFjOWJjMTZiBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--b359443cc553e2010a7628a625e1a61b27fdbf86;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWE1YzU4M2U2YjFmYzk5NTcyODdkYTk5ZTc1YTVhMWExBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--f3250f955f67bad4c425c8a6f2da52bea8e28c99;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 401 Unauthorized
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21a4e5b653b0f1ed10e23caea4b18fef
+      - 6be105199176b4b06f76314dd5444b7d
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"Authorization Error","errors":[{"resource":"Athlete","field":"access_token","code":"invalid"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 23:25:24 GMT
+  recorded_at: Sat, 25 Feb 2017 00:28:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_invalid_token_returns_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_invalid_token_returns_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?access_token=invalid_token&per_page=3
+    uri: https://www.strava.com/api/v3/athlete/activities?access_token=invalid_token&per_page=7
     body:
       encoding: US-ASCII
       string: ''
@@ -23,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 18:33:38 GMT
+      - Fri, 24 Feb 2017 23:25:24 GMT
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTZkZWM0NjVjMTUzZDVjYWVmNWM4MzQxNzA1MGY0ZDIwBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--432d99830ddf30b177c4605c0b6097c9d0b6453b;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTUyMzRkYjc5ODNmNzZkNWUyOWQzMWMxZmFjOWJjMTZiBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--b359443cc553e2010a7628a625e1a61b27fdbf86;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 401 Unauthorized
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89797ee5b36a21c1e11af3a4414dc117
+      - 21a4e5b653b0f1ed10e23caea4b18fef
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"Authorization Error","errors":[{"resource":"Athlete","field":"access_token","code":"invalid"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 18:33:39 GMT
+  recorded_at: Fri, 24 Feb 2017 23:25:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_valid_token_returns_3_most_recent_polylines.yml
+++ b/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_valid_token_returns_3_most_recent_polylines.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?access_token=<ACCESS_TOKEN>&per_page=3
+    uri: https://www.strava.com/api/v3/athlete/activities?access_token=<ACCESS_TOKEN>&per_page=7
     body:
       encoding: US-ASCII
       string: ''
@@ -23,28 +23,28 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 18:33:38 GMT
+      - Fri, 24 Feb 2017 23:25:24 GMT
       Etag:
-      - W/"f0827a546cc74cc1552b0eb48ac97b56"
+      - W/"72ce9c580a8032e0e2277d59c56fc7c2"
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTE1YmYyYzdmMTE5NzRiMjlhYTZkNjhlMjYwNjk3MGNkBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--c24754230e324aaa248eac28a775a3502dc05a9b;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWFmN2QxYzAzYzczMWNlYzA3ZjA1YzIxOTNkNjhlMTI4BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--401255c41d56f431bb7fdf1b4212349fa9d5964f;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 200 OK
       Strava-Athlete-Upload-Version:
-      - 51ab7e215dabab38aace5691faca731e
+      - d4734f82304b91efb9c7be9c3eacd1af
       X-Frame-Options:
       - DENY
       X-Ratelimit-Limit:
       - '600,30000'
       X-Ratelimit-Usage:
-      - '2,58'
+      - '13,118'
       X-Request-Id:
-      - 5b2e93a1236adc4ce77b06cfc497380e
+      - 3f1ddaad804698de05ec1d1785f7130a
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
-      - '1161'
+      - '2107'
       Connection:
       - keep-alive
     body:
@@ -55,7 +55,15 @@ http_interactions:
         Ride","distance":6748.0,"moving_time":1417,"elapsed_time":1959,"total_elevation_gain":65.3,"type":"Ride","start_date":"2017-02-21T01:09:58Z","start_date_local":"2017-02-20T18:09:58Z","timezone":"(GMT-07:00)
         America/Denver","utc_offset":-25200.0,"start_latlng":[39.75,-105.0],"end_latlng":[39.76,-105.06],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.75,"start_longitude":-105.0,"achievement_count":2,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a874072613","summary_polyline":"e_sqFd}y_Sl@WqBtBvBFFmBoMjRbVt^aThYsDhA|@xBoAfBjCzDJ`EpLx\\f@jI^l~CeDtBeFhNCtQ","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":4.762,"max_speed":11.7,"average_watts":84.8,"kilojoules":120.2,"device_watts":false,"has_heartrate":false,"elev_high":1642.3,"elev_low":1576.0,"pr_count":2,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":872969283,"resource_state":2,"external_id":"79EC0036-DB8C-42E9-AC26-937116D9B123","upload_id":965871320,"athlete":{"id":19613252,"resource_state":1},"name":"Afternoon
         Ride","distance":8115.6,"moving_time":1615,"elapsed_time":1793,"total_elevation_gain":58.8,"type":"Ride","start_date":"2017-02-20T00:32:51Z","start_date_local":"2017-02-19T17:32:51Z","timezone":"(GMT-07:00)
-        America/Denver","utc_offset":-25200.0,"start_latlng":[39.73,-105.0],"end_latlng":[39.76,-105.06],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.73,"start_longitude":-105.0,"achievement_count":6,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a872969283","summary_polyline":"kzmqFrj{_SkgA@Pr}A_L`AqXsHg@pDfCvOqH`MHflAs@bK_FEmEpFmFnPcBnMgFSkSrKgAjJpDzKAbF","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":5.025,"max_speed":8.8,"average_watts":89.0,"kilojoules":143.7,"device_watts":false,"has_heartrate":false,"elev_high":1641.2,"elev_low":1582.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10}]'
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.73,-105.0],"end_latlng":[39.76,-105.06],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.73,"start_longitude":-105.0,"achievement_count":6,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a872969283","summary_polyline":"kzmqFrj{_SkgA@Pr}A_L`AqXsHg@pDfCvOqH`MHflAs@bK_FEmEpFmFnPcBnMgFSkSrKgAjJpDzKAbF","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":5.025,"max_speed":8.8,"average_watts":89.0,"kilojoules":143.7,"device_watts":false,"has_heartrate":false,"elev_high":1641.2,"elev_low":1582.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":872526686,"resource_state":2,"external_id":"032881FD-3436-4602-A230-7C4D040406FB","upload_id":965417202,"athlete":{"id":19613252,"resource_state":1},"name":"Morning
+        Ride","distance":10291.0,"moving_time":1732,"elapsed_time":1795,"total_elevation_gain":43.8,"type":"Ride","start_date":"2017-02-19T17:10:33Z","start_date_local":"2017-02-19T10:10:33Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.76,-105.06],"end_latlng":[39.73,-104.97],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.76,"start_longitude":-105.06,"achievement_count":0,"kudos_count":0,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a872526686","summary_polyline":"egsqFtmd`SAmTvE{O~C_BGw|Co@gIgMq]G{CaCaDxAyBeAoBlEiBz`@{g@~YgCzNqFbpAo~@dHqP{C_BDwnAuOBnAZ","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":5.942,"max_speed":10.5,"average_watts":96.4,"kilojoules":167.0,"device_watts":false,"has_heartrate":false,"elev_high":1641.3,"elev_low":1576.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":870060166,"resource_state":2,"external_id":"8B2A3A6B-A409-480E-A9E7-664FCF6A7ECD","upload_id":962755487,"athlete":{"id":19613252,"resource_state":1},"name":"Afternoon
+        Ride","distance":5368.9,"moving_time":1083,"elapsed_time":1238,"total_elevation_gain":48.1,"type":"Ride","start_date":"2017-02-18T00:17:50Z","start_date_local":"2017-02-17T17:17:50Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.75,-105.0],"end_latlng":[39.75,-105.05],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.75,"start_longitude":-105.0,"achievement_count":6,"kudos_count":0,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a870060166","summary_polyline":"uzrqFhxz_SyCzEzIlOsSrXwD`Bv@|BgAlBvPhh@x@lNVvyCcD~BqFdNFxQ","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":4.957,"max_speed":9.0,"average_watts":110.0,"kilojoules":119.1,"device_watts":false,"has_heartrate":false,"elev_high":1625.0,"elev_low":1576.5,"pr_count":4,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":870047117,"resource_state":2,"external_id":"43AC557B-9962-45BE-B4AB-0ECB03D162AB","upload_id":962739093,"athlete":{"id":19613252,"resource_state":1},"name":"Afternoon
+        Ride","distance":9151.6,"moving_time":1992,"elapsed_time":90986,"total_elevation_gain":57.8,"type":"Ride","start_date":"2017-02-16T23:00:57Z","start_date_local":"2017-02-16T16:00:57Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.77,-105.22],"end_latlng":[39.73,-105.0],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.77,"start_longitude":-105.22,"achievement_count":2,"kudos_count":0,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a870047117","summary_polyline":"oyvqFpbfaSgH_@kBnDgMD}QyDqAqClqAsHzz@ip^hSN?ugAtE{P|@uApTo@tEaUxEmJxEgChE~@FszAfG{HAmFoBmF^{HnX|HvKyAZc|AbfAs@","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":4.594,"max_speed":11.1,"average_watts":82.9,"kilojoules":165.1,"device_watts":false,"has_heartrate":false,"elev_high":2004.9,"elev_low":1582.1,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10},{"id":868441229,"resource_state":2,"external_id":"A8E68656-F471-465B-9E04-BC82FACBB260","upload_id":961037581,"athlete":{"id":19613252,"resource_state":1},"name":"Morning
+        Ride","distance":7196.7,"moving_time":1164,"elapsed_time":1318,"total_elevation_gain":10.0,"type":"Ride","start_date":"2017-02-16T14:43:09Z","start_date_local":"2017-02-16T07:43:09Z","timezone":"(GMT-07:00)
+        America/Denver","utc_offset":-25200.0,"start_latlng":[39.76,-105.06],"end_latlng":[39.75,-105.0],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.76,"start_longitude":-105.06,"achievement_count":1,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a868441229","summary_polyline":"ggsqFdmd`S@oShE{ObD_C?oyCo@mKoQqh@`B_CmAwAdEuAnSsYiP}VjJgNqBqFwBk@vE~AgFuC`@cAErBV_B~AdC","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":6.183,"max_speed":16.7,"average_watts":84.3,"kilojoules":98.1,"device_watts":false,"has_heartrate":false,"elev_high":1642.4,"elev_low":1576.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10}]'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 18:33:38 GMT
+  recorded_at: Fri, 24 Feb 2017 23:25:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_valid_token_returns_3_most_recent_polylines.yml
+++ b/spec/fixtures/vcr_cassettes/strava/service_recent_routes_token_valid_token_returns_3_most_recent_polylines.yml
@@ -23,11 +23,11 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2017 23:25:24 GMT
+      - Sat, 25 Feb 2017 00:28:51 GMT
       Etag:
       - W/"72ce9c580a8032e0e2277d59c56fc7c2"
       Set-Cookie:
-      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJWFmN2QxYzAzYzczMWNlYzA3ZjA1YzIxOTNkNjhlMTI4BjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--401255c41d56f431bb7fdf1b4212349fa9d5964f;
+      - _strava3_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTUyNzdiZjA2YzFmYWFkZmM4MTc3NjVjODliNGUxOWYwBjsAVEkiEGNsZWFyX2NsaWNrBjsARlQ%3D--82ef7440fd7b21f8247923ea730b9130c5037280;
         domain=strava.com; path=/; HttpOnly
       Status:
       - 200 OK
@@ -38,9 +38,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600,30000'
       X-Ratelimit-Usage:
-      - '13,118'
+      - '8,18'
       X-Request-Id:
-      - 3f1ddaad804698de05ec1d1785f7130a
+      - 51f661399c38d5143a10fed2a1e52308
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Content-Length:
@@ -65,5 +65,5 @@ http_interactions:
         Ride","distance":7196.7,"moving_time":1164,"elapsed_time":1318,"total_elevation_gain":10.0,"type":"Ride","start_date":"2017-02-16T14:43:09Z","start_date_local":"2017-02-16T07:43:09Z","timezone":"(GMT-07:00)
         America/Denver","utc_offset":-25200.0,"start_latlng":[39.76,-105.06],"end_latlng":[39.75,-105.0],"location_city":null,"location_state":null,"location_country":null,"start_latitude":39.76,"start_longitude":-105.06,"achievement_count":1,"kudos_count":1,"comment_count":0,"athlete_count":1,"photo_count":0,"map":{"id":"a868441229","summary_polyline":"ggsqFdmd`S@oShE{ObD_C?oyCo@mKoQqh@`B_CmAwAdEuAnSsYiP}VjJgNqBqFwBk@vE~AgFuC`@cAErBV_B~AdC","resource_state":2},"trainer":false,"commute":false,"manual":false,"private":false,"flagged":false,"gear_id":null,"average_speed":6.183,"max_speed":16.7,"average_watts":84.3,"kilojoules":98.1,"device_watts":false,"has_heartrate":false,"elev_high":1642.4,"elev_low":1576.0,"pr_count":0,"total_photo_count":0,"has_kudoed":false,"workout_type":10}]'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 23:25:24 GMT
+  recorded_at: Sat, 25 Feb 2017 00:28:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/api/v1/issues/index_spec.rb
+++ b/spec/requests/api/v1/issues/index_spec.rb
@@ -27,24 +27,6 @@ describe 'Issues API' do
     end
   end
 
-  context 'some issues belong to logged in current user' do
-    it 'returns all issues with correct current user boolean' do
-      create(:issue, user: logged_in_user, resolved: true)
-      create(:issue)
-
-      get '/api/v1/issues'
-
-      issues = JSON.parse(response.body)
-      current_user_issue = issues.first
-      other_user_issue = issues.last
-
-      expect(response).to be_success
-      expect(current_user_issue['current_user']).to eq 'belong'
-      expect(other_user_issue['current_user']).to eq 'not-belong'
-      expect(current_user_issue['resolved']).to eq 'resolved'
-    end
-  end
-
   context 'guest visitor' do
     it 'returns all issues with current user boolean false' do
       create_list(:issue, 2)

--- a/spec/requests/api/v1/recent_routes_spec.rb
+++ b/spec/requests/api/v1/recent_routes_spec.rb
@@ -11,7 +11,7 @@ describe 'Recent Routes API' do
 
       expect(response).to be_success
       expect(routes).to be_an Array
-      expect(routes.count).to eq 3
+      expect(routes.count).to eq 7
       expect(routes.first).to be_a String
     end
   end

--- a/spec/services/strava_service_spec.rb
+++ b/spec/services/strava_service_spec.rb
@@ -17,7 +17,7 @@ describe 'Strava Service' do
         routes = StravaService.recent_routes(ENV['ACCESS_TOKEN'])
 
         expect(routes).to be_a Array
-        expect(routes.count).to eq 3
+        expect(routes.count).to eq 7
         expect(routes.first).to be_a String
       end
     end


### PR DESCRIPTION
Change API to get the 7 most recent routes and show them all as skinny orange routes.

Edit how the belong class is added to pins to use the user id cookie.

@ski-climb Ready for review. Not much here.