### PR TITLE
Restrict lat/lon values to be physically possible

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,7 @@
 class Issue < ApplicationRecord
   validates :description, :category, :severity, :title, :latitude, :longitude, presence: true
+  validates_numericality_of :latitude, greater_than_or_equal_to: -90, less_than_or_equal_to: 90
+  validates_numericality_of :longitude, greater_than_or_equal_to: -180, less_than_or_equal_to: 180
 
   belongs_to :user, optional: true
   belongs_to :admin, optional: true

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Issue, type: :model do
     it { is_expected.to validate_presence_of :latitude }
     it { is_expected.to validate_presence_of :longitude }
     it { is_expected.to validate_presence_of :title }
+    it { is_expected.to validate_numericality_of(:latitude).is_greater_than_or_equal_to(-90).is_less_than_or_equal_to(90) }
+    it { is_expected.to validate_numericality_of(:longitude).is_greater_than_or_equal_to(-180).is_less_than_or_equal_to(180) }
   end
 
   context 'relationships' do


### PR DESCRIPTION
@kheppenstall Well that was simple.  For some reason I was thinking it might take more than this, but nope.  I checked it on the form too - works about how you would expect with error messages and all.