### PR TITLE
Ne fix missing lat lon

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -18,4 +18,16 @@ class Issue < ApplicationRecord
   def resolved_status
     resolved ? "Resolved" : "Open"
   end
+
+  def image_url
+    photos.first ? photos.first.url.url : ""
+  end
+
+  def rounded_latitude
+    latitude ? latitude.round(5) : "Not Recorded"
+  end
+
+  def rounded_longitude
+    longitude ? longitude.round(6) : "Not Recorded"
+  end
 end

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -1,7 +1,7 @@
 <div class="list-group">
   <%= link_to issue_path(@issue) do %>
     <div class="list-group-item">
-      <%= image_tag @issue.photos.first.url.url, class: "img-responsive center-block img-rounded", alt: @issue.title %>
+      <%= image_tag @issue.image_url, class: "img-responsive center-block img-rounded", alt: @issue.title %>
     </div>
   <% end %>
   <div class="list-group-item">
@@ -15,7 +15,7 @@
     <p class="list-group-item-text">Severity:</p>
     <h4 class="list-group-item-heading"><%= @issue.severity.capitalize %></h4>
     <p class="list-group-item-text">Coordinates:</p>
-    <h4 class="list-group-item-heading">(<%= @issue.latitude.round(4) %>, <%= @issue.longitude.round(4) %>)</h4>
+    <h4 class="list-group-item-heading">(<%= @issue.rounded_latitude %>, <%= @issue.rounded_longitude %>)</h4>
     <p class="list-group-item-text">Status:</p>
     <h4 class="list-group-item-heading"><%= @issue.resolved_status %></h4>
   </div>

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -151,4 +151,53 @@ RSpec.describe Issue, type: :model do
       end
     end
   end
+
+  describe "#image_url" do
+    context "when no photos are present" do
+      let!(:issue_without_photo) { Issue.create(title: "No photo",
+                                                description: "Really no photo",
+                                                severity: "low",
+                                                category: "obstacle")
+      }
+      it "returns an empty string" do
+        expect(issue_without_photo.image_url).to eq ""
+      end
+    end
+  end
+
+  describe "#rounded_latitude" do
+    let!(:issue_without_latitude) { create(:issue, latitude: nil) }
+
+    context "when the issue does not have a latitude" do
+      it "returns 'Not Recorded'" do
+        expect(issue_without_latitude.rounded_latitude).to eq "Not Recorded"
+      end
+    end
+
+    let!(:issue_with_latitude) { create(:issue, latitude: -12.345) }
+
+    context "when the issue does have a latitude" do
+      it "returns the latitude rounded to 5 digits" do
+        expect(issue_with_latitude.rounded_latitude).to eq -12.345
+      end
+    end
+  end
+
+  describe "#rounded_longitude" do
+    let!(:issue_without_longitude) { create(:issue, longitude: nil) }
+
+    context "when the issue does not have a longitude" do
+      it "returns 'Not Recorded'" do
+        expect(issue_without_longitude.rounded_longitude).to eq "Not Recorded"
+      end
+    end
+
+    let!(:issue_with_longitude) { create(:issue, longitude: 123.456) }
+
+    context "when the issue does have a longitude" do
+      it "returns the longitude rounded to 6 digits" do
+        expect(issue_with_longitude.rounded_longitude).to eq 123.456
+      end
+    end
+  end
 end


### PR DESCRIPTION
@kheppenstall I'm not 100% sure that this is a long term solution we want to use, but I can see the use case.

Here we go - if a user, for some lost connection reason or service outage (like yesterday with Amazon) allows an issue to get created but not saved with a lat/lon or photo, this will prevent the views from breaking and prevent Heroku from throwing a 500 error.

It doesn't feel great to have to need this code.  Maybe we can make the process more robust via a transaction.  On the other hand, yesterday was a great example that sometimes we just need to allow for some less than perfect data in the database.  Thoughts?