### PR TITLE
Rescue for malformed image

### DIFF
--- a/app/services/photo_service.rb
+++ b/app/services/photo_service.rb
@@ -29,7 +29,7 @@ class PhotoService
     end
 
     def set_issue_gps_data
-      if image && gps_data = EXIFR::JPEG.new(image.open).gps
+      if image && gps_data = EXIFR::JPEG.new(image.open).gps rescue nil
         issue.update(latitude: gps_data.latitude, longitude: gps_data.longitude)
         return true
       end


### PR DESCRIPTION
@kheppenstall I chased this down to the source code (https://github.com/remvee/exifr/blob/master/lib/exifr/jpeg.rb), and saw one comment about a possible (rescue http://stackoverflow.com/questions/4174947/return-statement) on SO.  For our case, this is when the photo does not have GPS data, so it's OK for it to return nil (as I added below) since all we need to do is 1) get to the next page so the user can add the lat/lon and 2) make sure the image actually gets uploaded, which it seemed to do the couple times I tested it out.

Still no idea why this has cropped up now....  My only guess is that it had to do with my url => image renaming in the ImageUploader, but I can't make the direct connection.